### PR TITLE
Fix dependency on mbed-drivers

### DIFF
--- a/module.json
+++ b/module.json
@@ -22,6 +22,6 @@
   },
   "testDependencies": {
     "unity": "^2.0.1",
-    "mbed-drivers": "~0.11.0"
+    "mbed-drivers": "^1.0.0"
   }
 }


### PR DESCRIPTION
Since we switched mbed-drivers to 1.0.0, use the proper dependency spec.