### PR TITLE
Removed duplicate dependency on greentea-client

### DIFF
--- a/module.json
+++ b/module.json
@@ -23,7 +23,6 @@
   },
   "testDependencies": {
     "unity": "^2.0.1",
-    "mbed-drivers": "^1.0.0",
-    "greentea-client": "~0.1.4"
+    "mbed-drivers": "^1.0.0"
   }
 }


### PR DESCRIPTION
greentea-client is listed as a direct dependency, so it doesn't need to
be listed again as a test dependency.